### PR TITLE
Refactor bot commands to use database for settings management

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Code Quality
+on:
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22' # Using the 2026 LTS version
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules/
 .nyc_output/
 .local-info
 .env
+database.db
+database.db-journal

--- a/README.md
+++ b/README.md
@@ -3,35 +3,139 @@ Gary is a Discord bot made for a D&D group. Currently under active development.
 
 ## Requirements
 - Node.js >= 22
-- A Discord bot token placed in `config.json` (`token` field)
+- A Discord bot token placed in `.env` (`DISCORD_TOKEN` field)
+- SQLite database (created automatically on first run)
 
-## Quick start
-1. Install dependencies:
+## Setup
 
+### 1. Install dependencies
 ```bash
 npm install
 ```
 
-2. Run tests and lint/format:
+This installs all required packages including `better-sqlite3` for SQLite database support.
 
-```bash
-npm test
-npm run lint
-npm run format
+### 2. Configure bot credentials
+Create/update `.env` with your Discord bot credentials:
+```env
+DISCORD_TOKEN=YOUR_BOT_TOKEN
+CLIENT_ID=YOUR_CLIENT_ID
+GUILD_ID=YOUR_GUILD_ID
 ```
 
-3. Start the bot (production):
+Create/update `config.json` with bot-level settings:
+```json
+{
+  "owner": "YOUR_DISCORD_USER_ID",
+  "nextSession": 1774315200,
+  "dayOfMessageSent": false,
+  "fiveMinuteWarningSent": false
+}
+```
 
+**Note:** Sensitive credentials are in `.env` (ignored by git). Bot-level settings are in `config.json`. Guild-specific settings (announcement channel, next session time, etc.) are stored in the SQLite database.
+
+### 3. Migrate existing data (if upgrading from config-based storage)
+If you have existing guild settings in `config.json`, migrate them to the database:
+
+```bash
+node db/migrate.js YOUR_GUILD_ID
+```
+
+Replace `YOUR_GUILD_ID` with your Discord server ID. You can find this by enabling Developer Mode in Discord and right-clicking your server.
+
+**Example:**
+```bash
+node db/migrate.js 532730993962909697
+```
+
+The migration script will:
+- Read existing guild settings from `config.json`
+- Transfer them to `database.db` under the specified guild ID
+- Validate data integrity and prevent overwrites
+
+### 4. Run tests and validation
+```bash
+npm test       # Run test suite
+npm run lint   # Check code style
+npm run format # Format code
+```
+
+## Running the Bot
+
+### Production
 ```bash
 npm start
 ```
 
-4. Start in development (auto-restarts):
-
+### Development (auto-restart on file changes)
 ```bash
 npm run dev
 ```
 
-Notes
-- The project now uses Discord Slash Commands. Before using the bot you should register the commands with Discord (via the Developer Portal or an automated deploy script). If you'd like, I can add a deploy script to register `src/commands` with Discord.
+## Database
+
+Gary uses SQLite (`database.db`) for persistent guild configuration. The database is created automatically on first run.
+
+### Guild Settings Schema
+```sql
+CREATE TABLE guild_settings (
+  guild_id TEXT PRIMARY KEY,
+  next_session INTEGER,
+  announcement_channel TEXT,
+  announcement_role TEXT,
+  day_of_message_sent INTEGER,
+  five_minute_warning_sent INTEGER,
+  created_at DATETIME,
+  updated_at DATETIME
+)
+```
+
+### Accessing Guild Settings Programmatically
+```javascript
+const { getSettings, setSettings } = require("./db/dal.js");
+
+// Get settings for a guild
+const settings = getSettings("532730993962909697");
+
+// Update settings
+setSettings("532730993962909697", {
+  nextSession: 1774315200,
+  announcementChannel: "channel-id",
+  announcementRole: "role-id",
+  dayOfMessageSent: false,
+  fiveMinuteWarningSent: false,
+});
+```
+
+## Commands
+
+The bot uses Discord Slash Commands. Available commands:
+- `/setnext` - Set the next session timestamp
+- `/setchannel` - Set the announcement channel
+- `/setrole` - Set the announcement role to mention
+- `/next` - Display the next session time
+
+**Note:** Before using the bot, register these commands with Discord via the Developer Portal or using the deploy script:
+```bash
+npm run deploy
+```
+
+## Architecture
+
+- **`src/index.js`** - Bot entry point and event handlers
+- **`src/commands/`** - Slash command implementations
+- **`src/events/`** - Discord event listeners
+- **`db/init.js`** - Database initialization
+- **`db/dal.js`** - Data Access Layer (get/set guild settings)
+- **`db/migrate.js`** - Migration tool for config.json → SQLite
+- **`scheduler.js`** - Scheduled announcements for sessions
+- **`test/`** - Test suites for commands, database, and scheduler
+
+## Notes
+
+- The project uses Discord Slash Commands which require registration with Discord
+- Guild-specific data is now persisted in SQLite for multi-guild support
+- The bot credential (`token`) and `owner` must be kept in `config.json` for security
+
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,1 @@
-{
-  "clientId": "YOUR_DISCORD_CLIENT_BOT_ID_HERE",
-  "token": "YOUR_DISCORD_BOT_TOKEN_HERE"
-}
+{}

--- a/db/dal.js
+++ b/db/dal.js
@@ -1,0 +1,186 @@
+const { initializeDatabase } = require("./init.js");
+
+let db = null;
+
+/**
+ * Get or initialize the database connection
+ * @returns {Database.Database} The database instance
+ */
+function getDatabase() {
+  if (!db) {
+    db = initializeDatabase();
+  }
+  return db;
+}
+
+/**
+ * Retrieve guild settings from the database
+ * @param {string} guildId - The Discord Guild ID
+ * @returns {object|null} The guild settings or null if not found
+ */
+function getSettings(guildId) {
+  try {
+    const database = getDatabase();
+    const stmt = database.prepare("SELECT * FROM guild_settings WHERE guild_id = ?");
+    const row = stmt.get(guildId);
+
+    if (!row) {
+      return null;
+    }
+
+    // Convert integers back to booleans for flag fields
+    return {
+      guildId: row.guild_id,
+      nextSession: row.next_session,
+      announcementChannel: row.announcement_channel,
+      announcementRole: row.announcement_role,
+      dayOfMessageSent: row.day_of_message_sent === 1,
+      fiveMinuteWarningSent: row.five_minute_warning_sent === 1,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  } catch (error) {
+    console.error(`✗ Error retrieving settings for guild ${guildId}:`, error.message);
+    throw error;
+  }
+}
+
+/**
+ * Upsert (insert or update) guild settings in the database
+ * @param {string} guildId - The Discord Guild ID
+ * @param {object} settings - The settings object
+ * @param {number} [settings.nextSession] - Unix timestamp of next session
+ * @param {string} [settings.announcementChannel] - Channel ID for announcements
+ * @param {string} [settings.announcementRole] - Role ID to mention in announcements
+ * @param {boolean} [settings.dayOfMessageSent] - Flag for day-of announcement sent
+ * @param {boolean} [settings.fiveMinuteWarningSent] - Flag for 5-minute warning sent
+ * @returns {void}
+ */
+function setSettings(guildId, settings) {
+  try {
+    const database = getDatabase();
+
+    // Check if record exists
+    const exists = database.prepare("SELECT 1 FROM guild_settings WHERE guild_id = ?").get(guildId);
+
+    if (exists) {
+      // Update existing record
+      const stmt = database.prepare(
+        `UPDATE guild_settings 
+         SET next_session = ?, 
+             announcement_channel = ?, 
+             announcement_role = ?,
+             day_of_message_sent = ?,
+             five_minute_warning_sent = ?,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE guild_id = ?`,
+      );
+
+      stmt.run(
+        settings.nextSession ?? null,
+        settings.announcementChannel ?? null,
+        settings.announcementRole ?? null,
+        settings.dayOfMessageSent ? 1 : 0,
+        settings.fiveMinuteWarningSent ? 1 : 0,
+        guildId,
+      );
+    } else {
+      // Insert new record
+      const stmt = database.prepare(
+        `INSERT INTO guild_settings 
+         (guild_id, next_session, announcement_channel, announcement_role, day_of_message_sent, five_minute_warning_sent) 
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      );
+
+      stmt.run(
+        guildId,
+        settings.nextSession ?? null,
+        settings.announcementChannel ?? null,
+        settings.announcementRole ?? null,
+        settings.dayOfMessageSent ? 1 : 0,
+        settings.fiveMinuteWarningSent ? 1 : 0,
+      );
+    }
+
+    console.log(`✓ Settings saved for guild ${guildId}`);
+  } catch (error) {
+    console.error(`✗ Error setting settings for guild ${guildId}:`, error.message);
+    throw error;
+  }
+}
+
+/**
+ * Delete guild settings from the database
+ * @param {string} guildId - The Discord Guild ID
+ * @returns {void}
+ */
+function deleteSettings(guildId) {
+  try {
+    const database = getDatabase();
+    const stmt = database.prepare("DELETE FROM guild_settings WHERE guild_id = ?");
+    stmt.run(guildId);
+    console.log(`✓ Settings deleted for guild ${guildId}`);
+  } catch (error) {
+    console.error(`✗ Error deleting settings for guild ${guildId}:`, error.message);
+    throw error;
+  }
+}
+
+/**
+ * Retrieve a bot setting from the database
+ * @param {string} key - The setting key
+ * @returns {string|null} The setting value or null if not found
+ */
+function getBotSetting(key) {
+  try {
+    const database = getDatabase();
+    const stmt = database.prepare("SELECT value FROM bot_settings WHERE key = ?");
+    const row = stmt.get(key);
+    return row ? row.value : null;
+  } catch (error) {
+    console.error(`✗ Error retrieving bot setting ${key}:`, error.message);
+    throw error;
+  }
+}
+
+/**
+ * Set a bot setting in the database
+ * @param {string} key - The setting key
+ * @param {string} value - The setting value
+ * @returns {void}
+ */
+function setBotSetting(key, value) {
+  try {
+    const database = getDatabase();
+    const stmt = database.prepare(
+      "INSERT OR REPLACE INTO bot_settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+    );
+    stmt.run(key, value);
+    console.log(`✓ Bot setting ${key} updated`);
+  } catch (error) {
+    console.error(`✗ Error setting bot setting ${key}:`, error.message);
+    throw error;
+  }
+}
+
+/**
+ * Close the database connection
+ * @returns {void}
+ */
+function closeDatabase() {
+  if (db) {
+    db.close();
+    db = null;
+    console.log("✓ Database connection closed");
+  }
+}
+
+module.exports = {
+  getDatabase,
+  getSettings,
+  setSettings,
+  deleteSettings,
+  getBotSetting,
+  setBotSetting,
+  closeDatabase,
+};

--- a/db/init.js
+++ b/db/init.js
@@ -1,0 +1,50 @@
+const Database = require("better-sqlite3");
+const path = require("node:path");
+
+/**
+ * Initialize the SQLite database and create tables
+ * @returns {Database.Database} The database instance
+ */
+function initializeDatabase() {
+  try {
+    const dbPath = path.resolve(__dirname, "..", "database.db");
+    const db = new Database(dbPath);
+
+    // Enable foreign keys
+    db.pragma("foreign_keys = ON");
+
+    // Create guild_settings table if it doesn't exist
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS guild_settings (
+        guild_id TEXT PRIMARY KEY,
+        next_session INTEGER,
+        announcement_channel TEXT,
+        announcement_role TEXT,
+        day_of_message_sent INTEGER DEFAULT 0,
+        five_minute_warning_sent INTEGER DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    // Create bot_settings table if it doesn't exist
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS bot_settings (
+        key TEXT PRIMARY KEY,
+        value TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    console.log("✓ Database initialized successfully");
+    return db;
+  } catch (error) {
+    console.error("✗ Database initialization failed:", error.message);
+    throw error;
+  }
+}
+
+module.exports = {
+  initializeDatabase,
+};

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * Migration script to transfer data from config.json to SQLite database
+ * Usage: node db/migrate.js <guildId>
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { getSettings, setSettings, closeDatabase } = require("./dal.js");
+
+async function migrateFromConfigJson(guildId) {
+  if (!guildId) {
+    console.error("✗ Error: Guild ID is required");
+    console.log("Usage: node db/migrate.js <guildId>");
+    process.exit(1);
+  }
+
+  try {
+    const configPath = path.resolve(__dirname, "..", "config.json");
+
+    // Check if config.json exists
+    if (!fs.existsSync(configPath)) {
+      console.error(`✗ Error: config.json not found at ${configPath}`);
+      process.exit(1);
+    }
+
+    // Read config.json
+    console.log("📖 Reading config.json...");
+    const configContent = fs.readFileSync(configPath, "utf-8");
+    const config = JSON.parse(configContent);
+
+    // Validate required fields for migration
+    if (!config.nextSession && !config.announcementChannel && !config.announcementRole) {
+      console.warn("⚠ Warning: config.json appears to be empty or missing guild settings");
+    }
+
+    // Prepare settings for database
+    const settingsToMigrate = {
+      nextSession: config.nextSession || null,
+      announcementChannel: config.announcementChannel || null,
+      announcementRole: config.announcementRole || null,
+      dayOfMessageSent: config.dayOfMessageSent || false,
+      fiveMinuteWarningSent: config.fiveMinuteWarningSent || false,
+    };
+
+    console.log(`\n📝 Data to migrate to Guild ${guildId}:`);
+    console.log(JSON.stringify(settingsToMigrate, null, 2));
+
+    // Check if settings already exist for this guild
+    const existingSettings = getSettings(guildId);
+    if (existingSettings) {
+      console.warn(`\n⚠ Warning: Settings already exist for guild ${guildId}`);
+      console.error(
+        "✗ Migration aborted to prevent data loss. Delete existing settings first if you want to overwrite.",
+      );
+      process.exit(1);
+    }
+
+    // Migrate data to database
+    console.log(`\n🔄 Migrating data to database for guild ${guildId}...`);
+    setSettings(guildId, settingsToMigrate);
+
+    // Verify migration
+    const migratedSettings = getSettings(guildId);
+    if (migratedSettings) {
+      console.log("\n✓ Migration successful!");
+      console.log("Migrated settings:");
+      console.log(JSON.stringify(migratedSettings, null, 2));
+    } else {
+      console.error("✗ Migration verification failed: Settings not found in database");
+      process.exit(1);
+    }
+
+    console.log("\n💡 Next steps:");
+    console.log("1. Update scheduler.js to use the DAL module");
+    console.log("2. Update src/commands/setrole.js to use the DAL module");
+    console.log("3. Update src/commands/setnext.js to use the DAL module (if it exists)");
+    console.log("4. Update src/commands/setchannel.js to use the DAL module (if it exists)");
+    console.log("5. Keep config.json for bot token and clientId (move guild-specific data only)");
+  } catch (error) {
+    console.error("✗ Migration failed:", error.message);
+    if (error instanceof SyntaxError) {
+      console.error("   (Invalid JSON in config.json)");
+    }
+    process.exit(1);
+  } finally {
+    closeDatabase();
+  }
+}
+
+// Run migration
+const guildId = process.argv[2];
+migrateFromConfigJson(guildId);

--- a/deploy.js
+++ b/deploy.js
@@ -4,7 +4,8 @@ const { REST, Routes } = require("discord.js"); // Import directly from discord.
 const fs = require("node:fs");
 const path = require("node:path"); // Use path for more reliable file locating
 
-const { clientId, guildId } = require("./config.json");
+const clientId = process.env.CLIENT_ID;
+const guildId = process.env.GUILD_ID;
 const token = process.env.DISCORD_TOKEN;
 
 const commands = [];

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,0 +1,9 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.browser } },
+  tseslint.configs.recommended,
+]);

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,9 +1,24 @@
 import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
-import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.browser } },
-  tseslint.configs.recommended,
-]);
+export default [
+  {
+    files: ["**/*.{js,mjs,cjs}"],
+    languageOptions: { globals: globals.node },
+    rules: {
+      ...js.configs.recommended.rules
+    }
+  },
+  {
+    files: ["**/*.{ts,mts,cts}"],
+    languageOptions: { globals: globals.node },
+    rules: {
+      ...tseslint.configs.recommended.rules
+    }
+  },
+  {
+    files: ["test/**/*.{js,mjs,cjs,ts,mts,cts}"],
+    languageOptions: { globals: { ...globals.node, ...globals.mocha } }
+  }
+];

--- a/gary.js
+++ b/gary.js
@@ -1,6 +1,6 @@
 const fs = require("node:fs");
 const { prefix, token } = require("./config.json");
-const { Client, Collection, GatewayIntentBits, Partials, EmbedBuilder } = require("discord.js");
+const { Client, Collection, GatewayIntentBits, Partials } = require("discord.js");
 
 const client = new Client({
   intents: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "jiti": "^2.6.1",
         "mocha": "^11.1.0",
         "nyc": "^18.0.0",
+        "proxyquire": "^2.1.3",
+        "sinon": "^21.0.3",
         "typescript-eslint": "^8.57.2"
       },
       "engines": {
@@ -1411,6 +1413,47 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-9.0.3.tgz",
+      "integrity": "sha512-ZgYY7Dc2RW+OUdnZ1DEHg00lhRt+9BjymPKHog4PRFzr1U3MbK57+djmscWyKxzO1qfunHqs4N45WWyKIFKpiQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -3136,6 +3179,20 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3768,6 +3825,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -4268,6 +4335,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -4395,6 +4472,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -5605,6 +5689,18 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -6073,6 +6169,47 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.3.tgz",
+      "integrity": "sha512-0x8TQFr8EjADhSME01u1ZK31yv2+bd6Z5NrBCHVM+n4qL1wFqbxftmeyi3bwlr49FbbzRfrqSFOpyHCOh/YmYA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "@sinonjs/samsam": "^9.0.3",
+        "diff": "^8.0.3",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/smart-buffer": {
@@ -6647,6 +6784,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.0",
+        "better-sqlite3": "^12.8.0",
         "bufferutil": "^4.1.0",
         "discord.js": "^14.17.0",
         "dotenv": "^17.3.1",
@@ -534,20 +535,20 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
-      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
-        "@discordjs/util": "^1.1.1",
+        "@discordjs/util": "^1.2.0",
         "@sapphire/async-queue": "^1.5.3",
-        "@sapphire/snowflake": "^3.5.3",
+        "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.16",
-        "magic-bytes.js": "^1.10.0",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.3"
+        "undici": "6.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -566,6 +567,25 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@discordjs/util": {
@@ -1369,6 +1389,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
@@ -1391,6 +1431,20 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1401,6 +1455,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/blessed": {
@@ -1422,9 +1496,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1482,6 +1556,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -1644,6 +1742,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -1903,6 +2007,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1911,6 +2030,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/default-require-extensions": {
@@ -1950,6 +2078,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -2044,6 +2181,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -2189,6 +2335,15 @@
       "integrity": "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg==",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/extrareqp2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/extrareqp2/-/extrareqp2-1.0.0.tgz",
@@ -2214,6 +2369,12 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
       "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==",
+      "license": "MIT"
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
     "node_modules/fill-range": {
@@ -2347,6 +2508,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2461,6 +2628,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/git-sha1/-/git-sha1-0.1.2.tgz",
       "integrity": "sha512-2e/nZezdVlyCopOCYHeW0onkbZg7xP1Ad6pndPy1rCygeRykefUS6r7oA5cJRGEFvseiaz5a/qUHFVX1dd6Isg==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
     "node_modules/glob": {
@@ -2658,6 +2831,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -2683,6 +2876,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -3232,6 +3431,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -3246,6 +3457,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -3269,6 +3489,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "11.7.5",
@@ -3331,6 +3557,12 @@
       "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
       "license": "MIT"
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/needle": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
@@ -3364,6 +3596,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-gyp-build": {
@@ -3449,9 +3693,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3647,9 +3891,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3909,6 +4153,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4086,9 +4339,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4376,6 +4629,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-on-spawn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
@@ -4438,6 +4718,16 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/python-shell": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-5.0.0.tgz",
@@ -4457,6 +4747,30 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -4467,6 +4781,20 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -4588,9 +4916,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4787,6 +5115,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -4907,6 +5280,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -5090,6 +5472,34 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
@@ -5116,9 +5526,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5221,6 +5631,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tv4": {
       "version": "1.3.0",
@@ -5334,6 +5756,12 @@
       "engines": {
         "node": ">=6.14.2"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -5499,6 +5927,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,14 @@
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
+        "@eslint/js": "^10.0.1",
         "chai": "^5.0.0",
+        "eslint": "^10.1.0",
+        "globals": "^17.4.0",
+        "jiti": "^2.6.1",
         "mocha": "^11.1.0",
-        "nyc": "^18.0.0"
+        "nyc": "^18.0.0",
+        "typescript-eslint": "^8.57.2"
       },
       "engines": {
         "node": ">=22"
@@ -638,6 +643,225 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1195,6 +1419,27 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -1213,6 +1458,275 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
+      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/type-utils": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
+      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.2",
+        "@typescript-eslint/types": "^8.57.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
+      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
+      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
+      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.2",
+        "@typescript-eslint/tsconfig-utils": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
+      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@vladfrangu/async_event_emitter": {
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
@@ -1221,6 +1735,29 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -1244,6 +1781,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/amp": {
@@ -2041,6 +2595,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/default-require-extensions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
@@ -2298,6 +2859,151 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.3",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2309,6 +3015,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
@@ -2365,11 +3097,38 @@
       "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fclone": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
       "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==",
       "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -2433,6 +3192,27 @@
       "bin": {
         "flat": "cli.js"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -2670,6 +3450,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2850,6 +3643,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -3182,6 +3985,16 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-git": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/js-git/-/js-git-0.7.8.tgz",
@@ -3226,6 +4039,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3246,6 +4080,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/lazy": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
@@ -3253,6 +4097,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.2.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/libsodium": {
@@ -3561,6 +4419,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/needle": {
@@ -4162,6 +5027,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4656,6 +5539,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/process-on-spawn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
@@ -4726,6 +5619,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/python-shell": {
@@ -5599,6 +6502,54 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5618,6 +6569,19 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-mixer": {
@@ -5672,6 +6636,19 @@
         "json-stringify-safe": "^5.0.1"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -5690,6 +6667,45 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
+      "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.57.2",
+        "@typescript-eslint/parser": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/undefsafe": {
@@ -5742,6 +6758,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/utf-8-validate": {
@@ -5819,6 +6845,16 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/worker-threads": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,14 @@
   "description": "This package is used for Gary, my DnD Discord bot.",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@eslint/js": "^10.0.1",
     "chai": "^5.0.0",
+    "eslint": "^10.1.0",
+    "globals": "^17.4.0",
+    "jiti": "^2.6.1",
     "mocha": "^11.1.0",
-    "nyc": "^18.0.0"
+    "nyc": "^18.0.0",
+    "typescript-eslint": "^8.57.2"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "axios": "^1.7.0",
+    "better-sqlite3": "^12.8.0",
     "bufferutil": "^4.1.0",
     "discord.js": "^14.17.0",
     "dotenv": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "jiti": "^2.6.1",
     "mocha": "^11.1.0",
     "nyc": "^18.0.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^21.0.3",
     "typescript-eslint": "^8.57.2"
   },
   "engines": {
@@ -44,7 +46,8 @@
     "deploy": "node deploy.js",
     "dev": "nodemon src/index.js",
     "format": "biome format --write .",
-    "lint": "biome check .",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "start": "node src/index.js",
     "test": "mocha"
   },

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,65 +1,99 @@
 const schedule = require("node-schedule");
-const fs = require("node:fs");
-const path = require("node:path");
 const { EmbedBuilder } = require("discord.js");
+const { getSettings, setSettings, getDatabase } = require("./db/dal.js");
 
 function startScheduler(client) {
   schedule.scheduleJob("* * * * *", async () => {
-    const configPath = path.resolve(__dirname, "config.json");
-    const config = require(configPath);
+    try {
+      const db = getDatabase();
+      const allSettings = db.prepare("SELECT * FROM guild_settings").all();
 
-    if (!config.nextSession || !config.announcementChannel || !config.announcementRole) {
-      return;
-    }
+      for (const settings of allSettings) {
+        const guildId = settings.guild_id;
+        const config = getSettings(guildId);
 
-    const now = new Date();
-    const sessionTime = new Date(config.nextSession * 1000);
-    const fiveMinutesBefore = new Date(sessionTime.getTime() - 5 * 60 * 1000);
+        if (
+          !config ||
+          !config.nextSession ||
+          !config.announcementChannel ||
+          !config.announcementRole
+        ) {
+          continue;
+        }
 
-    // Reset sent flags if a new session is set
-    if (
-      config.nextSession &&
-      (config.dayOfMessageSent === undefined || config.fiveMinuteWarningSent === undefined)
-    ) {
-      config.dayOfMessageSent = false;
-      config.fiveMinuteWarningSent = false;
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-    }
+        const now = new Date();
+        const sessionTime = new Date(config.nextSession * 1000);
+        const fiveMinutesBefore = new Date(sessionTime.getTime() - 5 * 60 * 1000);
 
-    // Day of message (9am on the day of the session)
-    if (
-      now.getFullYear() === sessionTime.getFullYear() &&
-      now.getMonth() === sessionTime.getMonth() &&
-      now.getDate() === sessionTime.getDate() &&
-      now.getHours() === 9 &&
-      now.getMinutes() === 0 &&
-      !config.dayOfMessageSent
-    ) {
-      const channel = await client.channels.fetch(config.announcementChannel);
-      if (channel) {
-        const message = await channel.send(
-          `<@&${config.announcementRole}> Today is the day! Are you available for the session at <t:${config.nextSession}:t>?`,
-        );
-        await message.react("👍");
-        await message.react("👎");
+        // Reset sent flags if a new session is set
+        if (config.nextSession && (!config.dayOfMessageSent || !config.fiveMinuteWarningSent)) {
+          setSettings(guildId, {
+            nextSession: config.nextSession,
+            announcementChannel: config.announcementChannel,
+            announcementRole: config.announcementRole,
+            dayOfMessageSent: false,
+            fiveMinuteWarningSent: false,
+          });
+        }
 
-        config.dayOfMessageSent = true;
-        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+        // Day of message (9am on the day of the session)
+        if (
+          now.getFullYear() === sessionTime.getFullYear() &&
+          now.getMonth() === sessionTime.getMonth() &&
+          now.getDate() === sessionTime.getDate() &&
+          now.getHours() === 9 &&
+          now.getMinutes() === 0 &&
+          !config.dayOfMessageSent
+        ) {
+          try {
+            const channel = await client.channels.fetch(config.announcementChannel);
+            if (channel) {
+              const message = await channel.send(
+                `<@&${config.announcementRole}> Today is the day! Are you available for the session at <t:${config.nextSession}:t>?`,
+              );
+              await message.react("👍");
+              await message.react("👎");
+
+              setSettings(guildId, {
+                nextSession: config.nextSession,
+                announcementChannel: config.announcementChannel,
+                announcementRole: config.announcementRole,
+                dayOfMessageSent: true,
+                fiveMinuteWarningSent: config.fiveMinuteWarningSent,
+              });
+            }
+          } catch (error) {
+            console.error(`Error sending day-of message for guild ${guildId}:`, error.message);
+          }
+        }
+
+        // 5-minute warning
+        if (
+          now.getTime() >= fiveMinutesBefore.getTime() &&
+          now.getTime() < sessionTime.getTime() &&
+          !config.fiveMinuteWarningSent
+        ) {
+          try {
+            const channel = await client.channels.fetch(config.announcementChannel);
+            if (channel) {
+              await channel.send(
+                `<@&${config.announcementRole}> The session is starting in 5 minutes!`,
+              );
+              setSettings(guildId, {
+                nextSession: config.nextSession,
+                announcementChannel: config.announcementChannel,
+                announcementRole: config.announcementRole,
+                dayOfMessageSent: config.dayOfMessageSent,
+                fiveMinuteWarningSent: true,
+              });
+            }
+          } catch (error) {
+            console.error(`Error sending 5-minute warning for guild ${guildId}:`, error.message);
+          }
+        }
       }
-    }
-
-    // 5-minute warning
-    if (
-      now.getTime() >= fiveMinutesBefore.getTime() &&
-      now.getTime() < sessionTime.getTime() &&
-      !config.fiveMinuteWarningSent
-    ) {
-      const channel = await client.channels.fetch(config.announcementChannel);
-      if (channel) {
-        await channel.send(`<@&${config.announcementRole}> The session is starting in 5 minutes!`);
-        config.fiveMinuteWarningSent = true;
-        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-      }
+    } catch (error) {
+      console.error("Error in scheduler:", error.message);
     }
   });
 }

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,5 +1,4 @@
 const schedule = require("node-schedule");
-const { EmbedBuilder } = require("discord.js");
 const { getSettings, setSettings, getDatabase } = require("./db/dal.js");
 
 function startScheduler(client) {

--- a/src/commands/next.js
+++ b/src/commands/next.js
@@ -1,33 +1,36 @@
-const fs = require("node:fs");
-const path = require("node:path");
 const { SlashCommandBuilder } = require("discord.js");
+const { getSettings } = require("../../db/dal.js");
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("next")
     .setDescription("Displays the time of the next session."),
   async execute(interaction) {
-    const configPath = path.resolve(__dirname, "..", "..", "config.json");
-
-    let config;
-    try {
-      config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    } catch (error) {
-      console.error("Error reading config:", error);
+    const guildId = interaction.guildId;
+    if (!guildId) {
       return interaction.reply({
-        content: "There was an error retrieving the schedule.",
+        content: "This command can only be used in a server.",
         ephemeral: true,
       });
     }
 
-    const timestamp = config.nextSession;
+    try {
+      const settings = getSettings(guildId);
+      const timestamp = settings?.nextSession;
 
-    if (timestamp) {
-      await interaction.reply(`The next session is scheduled for <t:${timestamp}:R>`);
-    } else {
+      if (timestamp) {
+        await interaction.reply(`The next session is scheduled for <t:${timestamp}:R>`);
+      } else {
+        await interaction.reply({
+          content: "The next session has not been set yet. Use the `/setnext` command to set it.",
+          ephemeral: false,
+        });
+      }
+    } catch (error) {
+      console.error("Error retrieving schedule:", error);
       await interaction.reply({
-        content: "The next session has not been set yet. Use the `/setnext` command to set it.",
-        ephemeral: false,
+        content: "There was an error retrieving the schedule.",
+        ephemeral: true,
       });
     }
   },

--- a/src/commands/setchannel.js
+++ b/src/commands/setchannel.js
@@ -1,6 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { SlashCommandBuilder } = require("discord.js");
+const { getSettings, setSettings, getBotSetting } = require("../../db/dal.js");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -10,37 +11,51 @@ module.exports = {
       opt.setName("channel").setDescription("Channel for announcements").setRequired(true),
     ),
   async execute(interaction) {
-    const configPath = path.resolve(__dirname, "..", "..", "config.json");
-    const config = require(configPath);
+    try {
+      // Get owner from database (bot-level config, not guild-specific)
+      const owner = getBotSetting("owner");
 
-    if (interaction.user.id !== config.owner) {
-      return interaction.reply({
-        content: "Only the owner can set the announcement channel.",
-        ephemeral: true,
-      });
-    }
-
-    const channel = interaction.options.getChannel("channel");
-
-    if (!channel) {
-      return interaction.reply({ content: "Please provide a valid channel.", ephemeral: true });
-    }
-
-    config.announcementChannel = channel.id;
-
-    fs.writeFile(configPath, JSON.stringify(config, null, 2), (err) => {
-      if (err) {
-        console.error("Error writing to config.json:", err);
+      if (interaction.user.id !== owner) {
         return interaction.reply({
-          content: "There was an error setting the announcement channel.",
+          content: "Only the owner can set the announcement channel.",
           ephemeral: true,
         });
       }
+
+      const guildId = interaction.guildId;
+      if (!guildId) {
+        return interaction.reply({
+          content: "This command can only be used in a server.",
+          ephemeral: true,
+        });
+      }
+
+      const channel = interaction.options.getChannel("channel");
+
+      if (!channel) {
+        return interaction.reply({ content: "Please provide a valid channel.", ephemeral: true });
+      }
+
+      // Get existing settings or create new ones
+      const existingSettings = getSettings(guildId) || {};
+      setSettings(guildId, {
+        nextSession: existingSettings.nextSession,
+        announcementChannel: channel.id,
+        announcementRole: existingSettings.announcementRole,
+        dayOfMessageSent: existingSettings.dayOfMessageSent,
+        fiveMinuteWarningSent: existingSettings.fiveMinuteWarningSent,
+      });
 
       interaction.reply({
         content: `The announcement channel has been set to ${channel}.`,
         ephemeral: false,
       });
-    });
+    } catch (error) {
+      console.error("Error in setchannel command:", error.message);
+      interaction.reply({
+        content: "There was an error setting the announcement channel.",
+        ephemeral: true,
+      });
+    }
   },
 };

--- a/src/commands/setchannel.js
+++ b/src/commands/setchannel.js
@@ -1,5 +1,3 @@
-const fs = require("node:fs");
-const path = require("node:path");
 const { SlashCommandBuilder } = require("discord.js");
 const { getSettings, setSettings, getBotSetting } = require("../../db/dal.js");
 

--- a/src/commands/setnext.js
+++ b/src/commands/setnext.js
@@ -1,8 +1,5 @@
-const path = require("node:path");
-const fs = require("node:fs");
 const { SlashCommandBuilder } = require("discord.js");
-const { getSettings, setSettings } = require("../../db/dal.js");
-const { getBotSetting } = require("../../db/dal.js");
+const { getSettings, setSettings, getBotSetting } = require("../../db/dal.js");
 
 module.exports = {
   data: new SlashCommandBuilder()

--- a/src/commands/setnext.js
+++ b/src/commands/setnext.js
@@ -1,6 +1,8 @@
-const fs = require("node:fs");
 const path = require("node:path");
+const fs = require("node:fs");
 const { SlashCommandBuilder } = require("discord.js");
+const { getSettings, setSettings } = require("../../db/dal.js");
+const { getBotSetting } = require("../../db/dal.js");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -10,54 +12,66 @@ module.exports = {
       opt.setName("when").setDescription("Timestamp or date string").setRequired(true),
     ),
   async execute(interaction) {
-    const configPath = path.resolve(__dirname, "..", "..", "config.json");
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    try {
+      // Get owner from database (bot-level config, not guild-specific)
+      const owner = getBotSetting("owner");
 
-    if (interaction.user.id !== config.owner) {
-      return interaction.reply({
-        content: "Only the owner can set the next session time.",
-        ephemeral: true,
-      });
-    }
-
-    const dateString = interaction.options.getString("when");
-    let timestamp = Date.parse(dateString);
-
-    // If Date.parse failed, accept a numeric unix timestamp (seconds or ms)
-    if (Number.isNaN(timestamp)) {
-      if (/^\d+$/.test(dateString)) {
-        const num = Number(dateString);
-        timestamp = num < 1e12 ? num * 1000 : num;
-      }
-    }
-
-    if (Number.isNaN(timestamp)) {
-      return interaction.reply({
-        content: 'Please provide a valid date/time string in the format "YYYY-MM-DD HH:mm".',
-        ephemeral: true,
-      });
-    }
-
-    // Convert to Unix timestamp (seconds)
-    const unixTimestamp = Math.floor(timestamp / 1000);
-
-    config.nextSession = unixTimestamp;
-    config.dayOfMessageSent = false;
-    config.fiveMinuteWarningSent = false;
-
-    fs.writeFile(configPath, JSON.stringify(config, null, 2), (err) => {
-      if (err) {
-        console.error("Error writing to config.json:", err);
+      if (interaction.user.id !== owner) {
         return interaction.reply({
-          content: "There was an error setting the next session.",
+          content: "Only the owner can set the next session time.",
           ephemeral: true,
         });
       }
+
+      const guildId = interaction.guildId;
+      if (!guildId) {
+        return interaction.reply({
+          content: "This command can only be used in a server.",
+          ephemeral: true,
+        });
+      }
+
+      const dateString = interaction.options.getString("when");
+      let timestamp = Date.parse(dateString);
+
+      // If Date.parse failed, accept a numeric unix timestamp (seconds or ms)
+      if (Number.isNaN(timestamp)) {
+        if (/^\d+$/.test(dateString)) {
+          const num = Number(dateString);
+          timestamp = num < 1e12 ? num * 1000 : num;
+        }
+      }
+
+      if (Number.isNaN(timestamp)) {
+        return interaction.reply({
+          content: 'Please provide a valid date/time string in the format "YYYY-MM-DD HH:mm".',
+          ephemeral: true,
+        });
+      }
+
+      // Convert to Unix timestamp (seconds)
+      const unixTimestamp = Math.floor(timestamp / 1000);
+
+      // Get existing settings or create new ones
+      const existingSettings = getSettings(guildId) || {};
+      setSettings(guildId, {
+        nextSession: unixTimestamp,
+        announcementChannel: existingSettings.announcementChannel,
+        announcementRole: existingSettings.announcementRole,
+        dayOfMessageSent: false,
+        fiveMinuteWarningSent: false,
+      });
 
       interaction.reply({
         content: `Next session time has been set! Use the /next command to see it. Here is the raw timestamp for you to verify: <t:${unixTimestamp}:F>`,
         ephemeral: false,
       });
-    });
+    } catch (error) {
+      console.error("Error in setnext command:", error.message);
+      interaction.reply({
+        content: "There was an error setting the next session.",
+        ephemeral: true,
+      });
+    }
   },
 };

--- a/src/commands/setowner.js
+++ b/src/commands/setowner.js
@@ -1,14 +1,12 @@
-const fs = require("node:fs");
-const path = require("node:path");
 const { SlashCommandBuilder } = require("discord.js");
+const { getBotSetting, setBotSetting } = require("../../db/dal.js");
 
 module.exports = {
   data: new SlashCommandBuilder().setName("setowner").setDescription("Sets the owner of the bot."),
   async execute(interaction) {
-    const configPath = path.resolve(__dirname, "..", "..", "config.json");
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const existingOwner = getBotSetting("owner");
 
-    if (config.owner) {
+    if (existingOwner) {
       return interaction.reply({
         content: "The owner has already been set. Contact the current owner to change it.",
         ephemeral: true,
@@ -16,16 +14,15 @@ module.exports = {
     }
 
     const ownerId = interaction.user.id;
-    config.owner = ownerId;
 
     try {
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      setBotSetting("owner", ownerId);
       interaction.reply({
         content: "You have been set as the owner! You can now use the `/setnext` command.",
         ephemeral: false,
       });
     } catch (err) {
-      console.error("Error writing to config.json:", err);
+      console.error("Error setting owner:", err);
       return interaction.reply({
         content: "There was an error setting the owner.",
         ephemeral: true,

--- a/src/commands/setrole.js
+++ b/src/commands/setrole.js
@@ -1,6 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { SlashCommandBuilder } = require("discord.js");
+const { getSettings, setSettings, getBotSetting } = require("../../db/dal.js");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -10,36 +11,51 @@ module.exports = {
       opt.setName("role").setDescription("Role to mention").setRequired(true),
     ),
   async execute(interaction) {
-    const configPath = path.resolve(__dirname, "..", "config.json");
-    const config = require(configPath);
+    try {
+      // Get owner from database (bot-level config, not guild-specific)
+      const owner = getBotSetting("owner");
 
-    if (interaction.user.id !== config.owner) {
-      return interaction.reply({
-        content: "Only the owner can set the announcement role.",
-        ephemeral: true,
-      });
-    }
-
-    const role = interaction.options.getRole("role");
-
-    if (!role)
-      return interaction.reply({ content: "Please provide a valid role.", ephemeral: true });
-
-    config.announcementRole = role.id;
-
-    fs.writeFile(configPath, JSON.stringify(config, null, 2), (err) => {
-      if (err) {
-        console.error("Error writing to config.json:", err);
+      if (interaction.user.id !== owner) {
         return interaction.reply({
-          content: "There was an error setting the announcement role.",
+          content: "Only the owner can set the announcement role.",
           ephemeral: true,
         });
       }
+
+      const guildId = interaction.guildId;
+      if (!guildId) {
+        return interaction.reply({
+          content: "This command can only be used in a server.",
+          ephemeral: true,
+        });
+      }
+
+      const role = interaction.options.getRole("role");
+
+      if (!role) {
+        return interaction.reply({ content: "Please provide a valid role.", ephemeral: true });
+      }
+
+      // Get existing settings or create new ones
+      const existingSettings = getSettings(guildId) || {};
+      setSettings(guildId, {
+        nextSession: existingSettings.nextSession,
+        announcementChannel: existingSettings.announcementChannel,
+        announcementRole: role.id,
+        dayOfMessageSent: existingSettings.dayOfMessageSent,
+        fiveMinuteWarningSent: existingSettings.fiveMinuteWarningSent,
+      });
 
       interaction.reply({
         content: `The announcement role has been set to ${role}.`,
         ephemeral: false,
       });
-    });
+    } catch (error) {
+      console.error("Error in setrole command:", error.message);
+      interaction.reply({
+        content: "There was an error setting the announcement role.",
+        ephemeral: true,
+      });
+    }
   },
 };

--- a/src/commands/setrole.js
+++ b/src/commands/setrole.js
@@ -1,5 +1,3 @@
-const fs = require("node:fs");
-const path = require("node:path");
 const { SlashCommandBuilder } = require("discord.js");
 const { getSettings, setSettings, getBotSetting } = require("../../db/dal.js");
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const { token } = require("../config.json");
+require("dotenv").config();
+const token = process.env.DISCORD_TOKEN;
 const { Client, Collection, GatewayIntentBits, Partials } = require("discord.js");
 
 const client = new Client({

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,0 +1,434 @@
+const { assert } = require("chai");
+const fs = require("node:fs");
+const path = require("node:path");
+const setNextCommand = require("../src/commands/setnext.js");
+const setChannelCommand = require("../src/commands/setchannel.js");
+const setRoleCommand = require("../src/commands/setrole.js");
+const {
+  getSettings,
+  setSettings,
+  deleteSettings,
+  getBotSetting,
+  setBotSetting,
+  closeDatabase,
+} = require("../db/dal.js");
+
+// Test Constants
+const TEST_GUILD_ID = "532730993962909697";
+const TEST_OWNER_ID = "467015234826141716";
+const TEST_USER_ID = "user-123";
+const configPath = path.resolve(__dirname, "..", "config.json");
+const databasePath = path.resolve(__dirname, "..", "database.db");
+
+// Mock Interaction Factory
+const makeMockInteraction = ({
+  userId = TEST_USER_ID,
+  guildId = TEST_GUILD_ID,
+  options = {},
+} = {}) => ({
+  user: { id: userId },
+  guildId: guildId,
+  options: {
+    getString: (key) => options.string?.[key] || null,
+    getChannel: (key) => options.channel?.[key] || null,
+    getRole: (key) => options.role?.[key] || null,
+  },
+  reply: function (payload) {
+    this.lastReply = typeof payload === "string" ? payload : payload?.content || payload;
+    return Promise.resolve();
+  },
+  deferred: false,
+  replied: false,
+});
+
+describe("Updated Discord Commands with Database", () => {
+  let originalConfig;
+
+  before(() => {
+    // Save original config
+    originalConfig = fs.readFileSync(configPath, "utf8");
+  });
+
+  beforeEach(() => {
+    // Set up bot owner in database
+    setBotSetting("owner", TEST_OWNER_ID);
+
+    // Clean up any existing test guild settings
+    try {
+      deleteSettings(TEST_GUILD_ID);
+    } catch (error) {
+      // Ignore
+    }
+  });
+
+  afterEach(() => {
+    // Clean up test data
+    try {
+      deleteSettings(TEST_GUILD_ID);
+    } catch (error) {
+      // Ignore
+    }
+  });
+
+  after(() => {
+    // Restore original config
+    fs.writeFileSync(configPath, originalConfig, "utf8");
+
+    // Clean up database
+    closeDatabase();
+    if (fs.existsSync(databasePath)) {
+      try {
+        fs.unlinkSync(databasePath);
+      } catch (error) {
+        console.warn("Could not delete test database:", error.message);
+      }
+    }
+  });
+
+  describe("/setnext Command", () => {
+    it("should reject if user is not the owner", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_USER_ID,
+        options: {
+          string: { when: "2026-03-26 14:00" },
+        },
+      });
+
+      await setNextCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "Only the owner can set the next session time");
+    });
+
+    it("should reject if not used in a guild (no guildId)", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        guildId: null,
+        options: {
+          string: { when: "2026-03-26 14:00" },
+        },
+      });
+
+      await setNextCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "can only be used in a server");
+    });
+
+    it("should accept valid date string and save to database", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          string: { when: "2026-03-26 14:00" },
+        },
+      });
+
+      await setNextCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.isNotNull(settings);
+      assert.isNumber(settings.nextSession);
+      assert.isFalse(settings.dayOfMessageSent);
+      assert.isFalse(settings.fiveMinuteWarningSent);
+    });
+
+    it("should accept unix timestamp (seconds) and save to database", async () => {
+      const timestamp = Math.floor(Date.now() / 1000) + 86400; // Tomorrow
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          string: { when: timestamp.toString() },
+        },
+      });
+
+      await setNextCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.isNotNull(settings);
+      assert.equal(settings.nextSession, timestamp);
+    });
+
+    it("should accept unix timestamp (milliseconds) and convert to seconds", async () => {
+      const timestampMs = Date.now() + 86400000; // Tomorrow in ms
+      const expectedSeconds = Math.floor(timestampMs / 1000);
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          string: { when: timestampMs.toString() },
+        },
+      });
+
+      await setNextCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.isNotNull(settings);
+      assert.equal(settings.nextSession, expectedSeconds);
+    });
+
+    it("should reset warning flags when setting new session", async () => {
+      // Pre-set some flags
+      setSettings(TEST_GUILD_ID, {
+        nextSession: Math.floor(Date.now() / 1000),
+        dayOfMessageSent: true,
+        fiveMinuteWarningSent: true,
+      });
+
+      const newTimestamp = Math.floor(Date.now() / 1000) + 86400;
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          string: { when: newTimestamp.toString() },
+        },
+      });
+
+      await setNextCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.isFalse(settings.dayOfMessageSent);
+      assert.isFalse(settings.fiveMinuteWarningSent);
+    });
+
+    it("should preserve existing channel and role when updating timestamp", async () => {
+      // Pre-set channel and role
+      setSettings(TEST_GUILD_ID, {
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+      });
+
+      const timestamp = Math.floor(Date.now() / 1000) + 86400;
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          string: { when: timestamp.toString() },
+        },
+      });
+
+      await setNextCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.equal(settings.announcementChannel, "channel-123");
+      assert.equal(settings.announcementRole, "role-456");
+      assert.equal(settings.nextSession, timestamp);
+    });
+
+    it("should reject invalid date strings", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          string: { when: "invalid-date-string-xyz" },
+        },
+      });
+
+      await setNextCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "valid date/time string");
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.isNull(settings, "Should not create settings for invalid input");
+    });
+
+    it("should handle database errors gracefully", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          string: { when: Math.floor(Date.now() / 1000).toString() },
+        },
+      });
+
+      // Should not throw
+      assert.doesNotThrow(async () => {
+        await setNextCommand.execute(interaction);
+      });
+    });
+  });
+
+  describe("/setchannel Command", () => {
+    it("should reject if user is not the owner", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_USER_ID,
+        options: {
+          channel: { channel: { id: "channel-123" } },
+        },
+      });
+
+      await setChannelCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "Only the owner can set the announcement channel");
+    });
+
+    it("should reject if not used in a guild", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        guildId: null,
+      });
+
+      await setChannelCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "can only be used in a server");
+    });
+
+    it("should reject if no valid channel provided", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          channel: { channel: null },
+        },
+      });
+
+      await setChannelCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "valid channel");
+    });
+
+    it("should save channel to database", async () => {
+      const mockChannel = { id: "channel-123" };
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          channel: { channel: mockChannel },
+        },
+      });
+
+      await setChannelCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.isNotNull(settings);
+      assert.equal(settings.announcementChannel, "channel-123");
+    });
+
+    it("should preserve existing nextSession and role when updating channel", async () => {
+      setSettings(TEST_GUILD_ID, {
+        nextSession: 1774315200,
+        announcementRole: "role-456",
+      });
+
+      const mockChannel = { id: "channel-789" };
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          channel: { channel: mockChannel },
+        },
+      });
+
+      await setChannelCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.equal(settings.nextSession, 1774315200);
+      assert.equal(settings.announcementRole, "role-456");
+      assert.equal(settings.announcementChannel, "channel-789");
+    });
+  });
+
+  describe("/setrole Command", () => {
+    it("should reject if user is not the owner", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_USER_ID,
+        options: {
+          role: { role: { id: "role-123" } },
+        },
+      });
+
+      await setRoleCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "Only the owner can set the announcement role");
+    });
+
+    it("should reject if not used in a guild", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        guildId: null,
+      });
+
+      await setRoleCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "can only be used in a server");
+    });
+
+    it("should reject if no valid role provided", async () => {
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          role: { role: null },
+        },
+      });
+
+      await setRoleCommand.execute(interaction);
+
+      assert.include(interaction.lastReply, "valid role");
+    });
+
+    it("should save role to database", async () => {
+      const mockRole = { id: "role-123" };
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          role: { role: mockRole },
+        },
+      });
+
+      await setRoleCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.isNotNull(settings);
+      assert.equal(settings.announcementRole, "role-123");
+    });
+
+    it("should preserve existing nextSession and channel when updating role", async () => {
+      setSettings(TEST_GUILD_ID, {
+        nextSession: 1774315200,
+        announcementChannel: "channel-456",
+      });
+
+      const mockRole = { id: "role-789" };
+      const interaction = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        options: {
+          role: { role: mockRole },
+        },
+      });
+
+      await setRoleCommand.execute(interaction);
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.equal(settings.nextSession, 1774315200);
+      assert.equal(settings.announcementChannel, "channel-456");
+      assert.equal(settings.announcementRole, "role-789");
+    });
+  });
+
+  describe("Multi-Guild Support", () => {
+    it("should support settings for different guilds independently", async () => {
+      const guild1 = "guild-1";
+      const guild2 = "guild-2";
+
+      // Create interaction for guild 1
+      const interaction1 = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        guildId: guild1,
+        options: {
+          string: { when: "1774315200" },
+        },
+      });
+
+      await setNextCommand.execute(interaction1);
+
+      // Create interaction for guild 2
+      const interaction2 = makeMockInteraction({
+        userId: TEST_OWNER_ID,
+        guildId: guild2,
+        options: {
+          string: { when: "1774315300" },
+        },
+      });
+
+      await setNextCommand.execute(interaction2);
+
+      const settings1 = getSettings(guild1);
+      const settings2 = getSettings(guild2);
+
+      assert.equal(settings1.nextSession, 1774315200);
+      assert.equal(settings2.nextSession, 1774315300);
+
+      // Cleanup
+      deleteSettings(guild1);
+      deleteSettings(guild2);
+    });
+  });
+});

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -8,14 +8,13 @@ const {
   getSettings,
   setSettings,
   deleteSettings,
-  getBotSetting,
-  setBotSetting,
   closeDatabase,
+  setBotSetting,
 } = require("../db/dal.js");
 
 // Test Constants
 const TEST_GUILD_ID = "532730993962909697";
-const TEST_OWNER_ID = "467015234826141716";
+const TEST_OWNER_ID = "123456789";
 const TEST_USER_ID = "user-123";
 const configPath = path.resolve(__dirname, "..", "config.json");
 const databasePath = path.resolve(__dirname, "..", "database.db");
@@ -50,13 +49,13 @@ describe("Updated Discord Commands with Database", () => {
   });
 
   beforeEach(() => {
-    // Set up bot owner in database
+    // Set the owner for tests
     setBotSetting("owner", TEST_OWNER_ID);
 
     // Clean up any existing test guild settings
     try {
       deleteSettings(TEST_GUILD_ID);
-    } catch (error) {
+    } catch (_error) { // eslint-disable-line no-unused-vars
       // Ignore
     }
   });
@@ -65,7 +64,7 @@ describe("Updated Discord Commands with Database", () => {
     // Clean up test data
     try {
       deleteSettings(TEST_GUILD_ID);
-    } catch (error) {
+    } catch (_error) { // eslint-disable-line no-unused-vars
       // Ignore
     }
   });

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -1,0 +1,335 @@
+const { assert } = require("chai");
+const fs = require("node:fs");
+const path = require("node:path");
+const Database = require("better-sqlite3");
+
+// Import DAL functions
+const {
+  getDatabase,
+  getSettings,
+  setSettings,
+  deleteSettings,
+  closeDatabase,
+} = require("../db/dal.js");
+
+describe("Database DAL (Data Access Layer)", () => {
+  const testGuildId = "test-guild-123";
+  const testDatabasePath = path.resolve(__dirname, "..", "database.db");
+
+  afterEach(() => {
+    try {
+      // Clean up test data
+      deleteSettings(testGuildId);
+    } catch (error) {
+      // Ignore errors during cleanup
+    }
+  });
+
+  after(() => {
+    // Clean up database file after all tests
+    closeDatabase();
+    if (fs.existsSync(testDatabasePath)) {
+      try {
+        fs.unlinkSync(testDatabasePath);
+      } catch (error) {
+        console.warn("Could not delete test database file:", error.message);
+      }
+    }
+  });
+
+  describe("getSettings()", () => {
+    it("should return null for non-existent guild", () => {
+      const result = getSettings("non-existent-guild-xyz");
+      assert.isNull(result, "Should return null for non-existent guild");
+    });
+
+    it("should retrieve settings for an existing guild", () => {
+      const testSettings = {
+        nextSession: 1774315200,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        dayOfMessageSent: false,
+        fiveMinuteWarningSent: false,
+      };
+
+      setSettings(testGuildId, testSettings);
+      const result = getSettings(testGuildId);
+
+      assert.isNotNull(result, "Settings should exist");
+      assert.equal(result.guildId, testGuildId);
+      assert.equal(result.nextSession, testSettings.nextSession);
+      assert.equal(result.announcementChannel, testSettings.announcementChannel);
+      assert.equal(result.announcementRole, testSettings.announcementRole);
+      assert.isFalse(result.dayOfMessageSent);
+      assert.isFalse(result.fiveMinuteWarningSent);
+    });
+
+    it("should convert integer flags back to booleans", () => {
+      const testSettings = {
+        nextSession: 1774315200,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        dayOfMessageSent: true,
+        fiveMinuteWarningSent: true,
+      };
+
+      setSettings(testGuildId, testSettings);
+      const result = getSettings(testGuildId);
+
+      assert.isTrue(result.dayOfMessageSent, "Should convert integer 1 to boolean true");
+      assert.isTrue(result.fiveMinuteWarningSent, "Should convert integer 1 to boolean true");
+      assert.isBoolean(result.dayOfMessageSent);
+      assert.isBoolean(result.fiveMinuteWarningSent);
+    });
+
+    it("should include timestamps in returned object", () => {
+      const testSettings = {
+        nextSession: 1774315200,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+      };
+
+      setSettings(testGuildId, testSettings);
+      const result = getSettings(testGuildId);
+
+      assert.isNotNull(result.createdAt);
+      assert.isNotNull(result.updatedAt);
+      assert.isString(result.createdAt);
+      assert.isString(result.updatedAt);
+    });
+  });
+
+  describe("setSettings()", () => {
+    it("should create new settings for a guild (insert)", () => {
+      const testSettings = {
+        nextSession: 1774315200,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        dayOfMessageSent: false,
+        fiveMinuteWarningSent: false,
+      };
+
+      setSettings(testGuildId, testSettings);
+      const result = getSettings(testGuildId);
+
+      assert.isNotNull(result);
+      assert.equal(result.nextSession, 1774315200);
+    });
+
+    it("should update existing settings for a guild (upsert)", () => {
+      // First insert
+      const initialSettings = {
+        nextSession: 1774315200,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+      };
+
+      setSettings(testGuildId, initialSettings);
+
+      // Update
+      const updatedSettings = {
+        nextSession: 1774315300,
+        announcementChannel: "channel-789",
+        announcementRole: "role-789",
+        dayOfMessageSent: true,
+      };
+
+      setSettings(testGuildId, updatedSettings);
+      const result = getSettings(testGuildId);
+
+      assert.equal(result.nextSession, 1774315300, "Should update nextSession");
+      assert.equal(result.announcementChannel, "channel-789", "Should update announcementChannel");
+      assert.equal(result.announcementRole, "role-789", "Should update announcementRole");
+      assert.isTrue(result.dayOfMessageSent, "Should update dayOfMessageSent");
+    });
+
+    it("should handle partial updates (null values)", () => {
+      // Set initial settings
+      const initialSettings = {
+        nextSession: 1774315200,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+      };
+
+      setSettings(testGuildId, initialSettings);
+
+      // Update with null values (should preserve existing)
+      const partialUpdate = {
+        nextSession: 1774315300,
+        announcementChannel: null,
+        announcementRole: null,
+      };
+
+      setSettings(testGuildId, partialUpdate);
+      const result = getSettings(testGuildId);
+
+      assert.equal(result.nextSession, 1774315300);
+      assert.isNull(result.announcementChannel);
+      assert.isNull(result.announcementRole);
+    });
+
+    it("should set boolean flags correctly", () => {
+      const testSettings = {
+        nextSession: 1774315200,
+        dayOfMessageSent: true,
+        fiveMinuteWarningSent: false,
+      };
+
+      setSettings(testGuildId, testSettings);
+      const result = getSettings(testGuildId);
+
+      assert.isTrue(result.dayOfMessageSent);
+      assert.isFalse(result.fiveMinuteWarningSent);
+    });
+
+    it("should update timestamps on upsert", (done) => {
+      const testSettings = {
+        nextSession: 1774315200,
+      };
+
+      setSettings(testGuildId, testSettings);
+      const firstResult = getSettings(testGuildId);
+      const firstUpdatedAt = firstResult.updatedAt;
+
+      // Small delay to ensure timestamp difference
+      setTimeout(() => {
+        setSettings(testGuildId, {
+          nextSession: 1774315300,
+        });
+        const secondResult = getSettings(testGuildId);
+
+        // updatedAt should be more recent than before (though this might be tricky in tests)
+        assert.isNotNull(secondResult.updatedAt);
+        done();
+      }, 100);
+    });
+  });
+
+  describe("deleteSettings()", () => {
+    it("should delete settings for a guild", () => {
+      const testSettings = {
+        nextSession: 1774315200,
+        announcementChannel: "channel-123",
+      };
+
+      setSettings(testGuildId, testSettings);
+      assert.isNotNull(getSettings(testGuildId));
+
+      deleteSettings(testGuildId);
+      assert.isNull(getSettings(testGuildId), "Settings should be deleted");
+    });
+
+    it("should handle deletion of non-existent guild gracefully", () => {
+      // Should not throw an error
+      assert.doesNotThrow(() => {
+        deleteSettings("non-existent-guild-456");
+      });
+    });
+  });
+
+  describe("Database Integrity", () => {
+    it("should support multiple guilds independently", () => {
+      const guild1 = "guild-1";
+      const guild2 = "guild-2";
+
+      setSettings(guild1, {
+        nextSession: 1774315200,
+        announcementChannel: "channel-1",
+      });
+
+      setSettings(guild2, {
+        nextSession: 1774315300,
+        announcementChannel: "channel-2",
+      });
+
+      const result1 = getSettings(guild1);
+      const result2 = getSettings(guild2);
+
+      assert.equal(result1.nextSession, 1774315200);
+      assert.equal(result2.nextSession, 1774315300);
+      assert.equal(result1.announcementChannel, "channel-1");
+      assert.equal(result2.announcementChannel, "channel-2");
+
+      // Cleanup
+      deleteSettings(guild1);
+      deleteSettings(guild2);
+    });
+
+    it("should enforce guild_id as primary key", () => {
+      const testSettings = {
+        nextSession: 1774315200,
+      };
+
+      setSettings(testGuildId, testSettings);
+
+      // Getting database directly to verify schema
+      const db = getDatabase();
+      const result = db
+        .prepare("SELECT COUNT(*) as count FROM guild_settings WHERE guild_id = ?")
+        .get(testGuildId);
+
+      assert.equal(result.count, 1, "Should only have one record per guild_id");
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should handle database errors gracefully", () => {
+      // Test by providing valid input
+      assert.doesNotThrow(() => {
+        const testSettings = {
+          nextSession: 1774315200,
+        };
+        setSettings(testGuildId, testSettings);
+        getSettings(testGuildId);
+        deleteSettings(testGuildId);
+      });
+    });
+
+    it("should validate guild_id input", () => {
+      // Should work with empty string guild ID (SQLite allows it)
+      const emptyGuildId = "";
+      const testSettings = { nextSession: 1774315200 };
+
+      assert.doesNotThrow(() => {
+        setSettings(emptyGuildId, testSettings);
+        deleteSettings(emptyGuildId);
+      });
+    });
+  });
+});
+
+describe("Bot Settings (Database Integration)", () => {
+  const { getBotSetting, setBotSetting } = require("../db/dal.js");
+
+  after(() => {
+    closeDatabase();
+  });
+
+  describe("getBotSetting()", () => {
+    it("should return null for non-existent setting", () => {
+      const value = getBotSetting("nonexistent");
+      assert.isNull(value);
+    });
+
+    it("should retrieve a set setting", () => {
+      setBotSetting("test_key", "test_value");
+      const value = getBotSetting("test_key");
+      assert.equal(value, "test_value");
+    });
+  });
+
+  describe("setBotSetting()", () => {
+    it("should create a new setting", () => {
+      setBotSetting("new_key", "new_value");
+      const value = getBotSetting("new_key");
+      assert.equal(value, "new_value");
+    });
+
+    it("should update an existing setting", () => {
+      setBotSetting("update_key", "old_value");
+      setBotSetting("update_key", "new_value");
+      const value = getBotSetting("update_key");
+      assert.equal(value, "new_value");
+    });
+  });
+});

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -1,7 +1,4 @@
 const { assert } = require("chai");
-const fs = require("node:fs");
-const path = require("node:path");
-const Database = require("better-sqlite3");
 
 // Import DAL functions
 const {
@@ -14,13 +11,12 @@ const {
 
 describe("Database DAL (Data Access Layer)", () => {
   const testGuildId = "test-guild-123";
-  const testDatabasePath = path.resolve(__dirname, "..", "database.db");
 
   afterEach(() => {
     try {
       // Clean up test data
       deleteSettings(testGuildId);
-    } catch (error) {
+    } catch (_error) { // eslint-disable-line no-unused-vars
       // Ignore errors during cleanup
     }
   });
@@ -28,13 +24,13 @@ describe("Database DAL (Data Access Layer)", () => {
   after(() => {
     // Clean up database file after all tests
     closeDatabase();
-    if (fs.existsSync(testDatabasePath)) {
-      try {
-        fs.unlinkSync(testDatabasePath);
-      } catch (error) {
-        console.warn("Could not delete test database file:", error.message);
-      }
-    }
+    // if (fs.existsSync(testDatabasePath)) {
+    //   try {
+    //     fs.unlinkSync(testDatabasePath);
+    //   } catch (error) {
+    //     console.warn("Could not delete test database file:", error.message);
+    //   }
+    // }
   });
 
   describe("getSettings()", () => {
@@ -188,8 +184,6 @@ describe("Database DAL (Data Access Layer)", () => {
       };
 
       setSettings(testGuildId, testSettings);
-      const firstResult = getSettings(testGuildId);
-      const firstUpdatedAt = firstResult.updatedAt;
 
       // Small delay to ensure timestamp difference
       setTimeout(() => {

--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -4,12 +4,18 @@ const path = require("node:path");
 const nextCommand = require("../src/commands/next.js");
 const setNextCommand = require("../src/commands/setnext.js");
 const setOwnerCommand = require("../src/commands/setowner.js");
+let { getSettings, setSettings, setBotSetting } = require("../db/dal.js");
 
 const configPath = path.resolve(__dirname, "..", "config.json");
 
 let lastReply = "";
-const makeMockInteraction = ({ userId = "123456789", when = null } = {}) => ({
+const makeMockInteraction = ({
+  userId = "123456789",
+  when = null,
+  guildId = "test-guild",
+} = {}) => ({
   user: { id: userId },
+  guildId,
   options: { getString: (k) => when },
   reply: (payload) => {
     if (typeof payload === "string") lastReply = payload;
@@ -25,8 +31,8 @@ const makeMockInteraction = ({ userId = "123456789", when = null } = {}) => ({
 
 describe("Error handling", () => {
   it("next should handle config read error", () => {
-    const orig = fs.readFileSync;
-    fs.readFileSync = () => {
+    const orig = getSettings;
+    getSettings = () => {
       throw new Error("boom");
     };
 
@@ -35,26 +41,24 @@ describe("Error handling", () => {
 
     assert.equal(lastReply, "There was an error retrieving the schedule.");
 
-    fs.readFileSync = orig;
+    getSettings = orig;
   });
 
   it("setnext should handle write error", (done) => {
     // Ensure owner is set so the command proceeds
-    const origConfig = fs.readFileSync(configPath, "utf8");
-    const cfg = JSON.parse(origConfig);
-    cfg.owner = "123456789";
-    fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf8");
+    setBotSetting("owner", "123456789");
 
-    const origWrite = fs.writeFile;
-    fs.writeFile = (p, data, cb) => cb(new Error("disk"));
+    const origSet = setSettings;
+    setSettings = () => {
+      throw new Error("disk");
+    };
 
     const mockWithDone = makeMockInteraction({ when: Math.floor(Date.now() / 1000).toString() });
     mockWithDone.reply = (payload) => {
       const m = typeof payload === "string" ? payload : payload.content;
       lastReply = m;
       assert.equal(lastReply, "There was an error setting the next session.");
-      fs.writeFile = origWrite;
-      fs.writeFileSync(configPath, origConfig, "utf8");
+      setSettings = origSet;
       done();
     };
 
@@ -72,13 +76,8 @@ describe("Error handling", () => {
 
   it("setowner should handle write error", (done) => {
     // Clear owner for the test
-    const origConfig = fs.readFileSync(configPath, "utf8");
-    const cfg = JSON.parse(origConfig);
-    cfg.owner = undefined;
-    fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2), "utf8");
-
-    const origWriteSync = fs.writeFileSync;
-    fs.writeFileSync = () => {
+    const origSet = setBotSetting;
+    setBotSetting = () => {
       throw new Error("disk");
     };
 
@@ -87,8 +86,7 @@ describe("Error handling", () => {
       const m = typeof payload === "string" ? payload : payload.content;
       lastReply = m;
       assert.equal(lastReply, "There was an error setting the owner.");
-      fs.writeFileSync = origWriteSync;
-      fs.writeFileSync(configPath, origConfig, "utf8");
+      setBotSetting = origSet;
       done();
     };
 

--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -1,12 +1,6 @@
 const { assert } = require("chai");
-const fs = require("node:fs");
-const path = require("node:path");
-const nextCommand = require("../src/commands/next.js");
-const setNextCommand = require("../src/commands/setnext.js");
-const setOwnerCommand = require("../src/commands/setowner.js");
-let { getSettings, setSettings, setBotSetting } = require("../db/dal.js");
-
-const configPath = path.resolve(__dirname, "..", "config.json");
+const sinon = require("sinon");
+const proxyquire = require("proxyquire");
 
 let lastReply = "";
 const makeMockInteraction = ({
@@ -16,7 +10,7 @@ const makeMockInteraction = ({
 } = {}) => ({
   user: { id: userId },
   guildId,
-  options: { getString: (k) => when },
+  options: { getString: () => when },
   reply: (payload) => {
     if (typeof payload === "string") lastReply = payload;
     else if (payload?.content) lastReply = payload.content;
@@ -30,35 +24,51 @@ const makeMockInteraction = ({
 });
 
 describe("Error handling", () => {
+  let nextCommand, setNextCommand, setOwnerCommand;
+  let getSettingsStub, setSettingsStub, setBotSettingStub;
+
+  beforeEach(() => {
+    getSettingsStub = sinon.stub();
+    setSettingsStub = sinon.stub();
+    setBotSettingStub = sinon.stub();
+
+    nextCommand = proxyquire("../src/commands/next.js", {
+      "../../db/dal.js": { getSettings: getSettingsStub }
+    });
+
+    setNextCommand = proxyquire("../src/commands/setnext.js", {
+      "../../db/dal.js": { getSettings: getSettingsStub, setSettings: setSettingsStub, getBotSetting: setBotSettingStub }
+    });
+
+    setOwnerCommand = proxyquire("../src/commands/setowner.js", {
+      "../../db/dal.js": { setBotSetting: setBotSettingStub }
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it("next should handle config read error", () => {
-    const orig = getSettings;
-    getSettings = () => {
-      throw new Error("boom");
-    };
+    getSettingsStub.throws(new Error("boom"));
 
     const mock = makeMockInteraction();
     nextCommand.execute(mock);
 
     assert.equal(lastReply, "There was an error retrieving the schedule.");
-
-    getSettings = orig;
   });
 
   it("setnext should handle write error", (done) => {
     // Ensure owner is set so the command proceeds
-    setBotSetting("owner", "123456789");
+    setBotSettingStub.returns("123456789");
 
-    const origSet = setSettings;
-    setSettings = () => {
-      throw new Error("disk");
-    };
+    setSettingsStub.throws(new Error("disk"));
 
     const mockWithDone = makeMockInteraction({ when: Math.floor(Date.now() / 1000).toString() });
     mockWithDone.reply = (payload) => {
       const m = typeof payload === "string" ? payload : payload.content;
       lastReply = m;
       assert.equal(lastReply, "There was an error setting the next session.");
-      setSettings = origSet;
       done();
     };
 
@@ -66,6 +76,8 @@ describe("Error handling", () => {
   });
 
   it("setnext should require owner permission", () => {
+    setBotSettingStub.returns("different-owner");
+
     const mockNonOwner = makeMockInteraction({
       userId: "000000",
       when: Math.floor(Date.now() / 1000).toString(),
@@ -76,17 +88,13 @@ describe("Error handling", () => {
 
   it("setowner should handle write error", (done) => {
     // Clear owner for the test
-    const origSet = setBotSetting;
-    setBotSetting = () => {
-      throw new Error("disk");
-    };
+    setBotSettingStub.throws(new Error("disk"));
 
     const mockWithDone = makeMockInteraction();
     mockWithDone.reply = (payload) => {
       const m = typeof payload === "string" ? payload : payload.content;
       lastReply = m;
       assert.equal(lastReply, "There was an error setting the owner.");
-      setBotSetting = origSet;
       done();
     };
 

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,0 +1,334 @@
+const { assert } = require("chai");
+const fs = require("node:fs");
+const path = require("node:path");
+const { setSettings, getSettings, deleteSettings, closeDatabase } = require("../db/dal.js");
+
+const databasePath = path.resolve(__dirname, "..", "database.db");
+
+// Mock Discord Client and Channel
+const makeMockClient = () => ({
+  channels: {
+    fetch: async (channelId) => {
+      if (channelId === "valid-channel-id") {
+        return {
+          send: async (message) => ({
+            react: async (emoji) => {
+              // Mock reaction
+            },
+          }),
+        };
+      }
+      return null;
+    },
+  },
+});
+
+// We'll test the scheduler logic without actually scheduling
+describe("Scheduler Logic (Database Integration)", () => {
+  const TEST_GUILD_ID = "test-guild-scheduler";
+
+  afterEach(() => {
+    try {
+      deleteSettings(TEST_GUILD_ID);
+    } catch (error) {
+      // Ignore
+    }
+  });
+
+  after(() => {
+    closeDatabase();
+    if (fs.existsSync(databasePath)) {
+      try {
+        fs.unlinkSync(databasePath);
+      } catch (error) {
+        console.warn("Could not delete test database:", error.message);
+      }
+    }
+  });
+
+  describe("Scheduler Logic - Day of Message", () => {
+    it("should identify when it's the day of session (9am specific time check)", () => {
+      // Create a mock session for today at 9:15 AM
+      const now = new Date();
+      const sessionTime = new Date();
+      sessionTime.setHours(14, 0, 0, 0); // 2 PM today
+
+      const nextSession = Math.floor(sessionTime.getTime() / 1000);
+
+      setSettings(TEST_GUILD_ID, {
+        nextSession,
+        announcementChannel: "valid-channel-id",
+        announcementRole: "role-123",
+        dayOfMessageSent: false,
+        fiveMinuteWarningSent: false,
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      const sessionDate = new Date(settings.nextSession * 1000);
+
+      // Verify it's the same day
+      assert.equal(now.getFullYear(), sessionDate.getFullYear());
+      assert.equal(now.getMonth(), sessionDate.getMonth());
+      assert.equal(now.getDate(), sessionDate.getDate());
+    });
+
+    it("should identify when it's NOT the day of session", () => {
+      // Create a mock session for tomorrow
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(14, 0, 0, 0);
+
+      const sessionTime = Math.floor(tomorrow.getTime() / 1000);
+      const now = new Date();
+
+      setSettings(TEST_GUILD_ID, {
+        nextSession: sessionTime,
+        dayOfMessageSent: false,
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      const sessionDate = new Date(settings.nextSession * 1000);
+
+      // Verify it's NOT the same day
+      assert.notEqual(now.getDate(), sessionDate.getDate());
+    });
+
+    it("should track dayOfMessageSent flag correctly", () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+
+      setSettings(TEST_GUILD_ID, {
+        nextSession: timestamp,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        dayOfMessageSent: false,
+      });
+
+      let settings = getSettings(TEST_GUILD_ID);
+      assert.isFalse(settings.dayOfMessageSent);
+
+      // Update the flag
+      setSettings(TEST_GUILD_ID, {
+        nextSession: timestamp,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        dayOfMessageSent: true,
+      });
+
+      settings = getSettings(TEST_GUILD_ID);
+      assert.isTrue(settings.dayOfMessageSent);
+    });
+  });
+
+  describe("Scheduler Logic - 5-Minute Warning", () => {
+    it("should calculate 5-minute warning time correctly", () => {
+      const sessionTime = new Date();
+      sessionTime.setMinutes(sessionTime.getMinutes() + 10); // 10 minutes from now
+      const nextSession = Math.floor(sessionTime.getTime() / 1000);
+      const fiveMinutesBefore = new Date(sessionTime.getTime() - 5 * 60 * 1000);
+
+      setSettings(TEST_GUILD_ID, {
+        nextSession,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        fiveMinuteWarningSent: false,
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      const now = new Date();
+
+      // Verify the 5-minute window has not started yet (session is 10 min away)
+      assert.isTrue(now.getTime() < fiveMinutesBefore.getTime());
+    });
+
+    it("should track fiveMinuteWarningSent flag correctly", () => {
+      const timestamp = Math.floor(Date.now() / 1000) + 300; // 5 min in future
+
+      setSettings(TEST_GUILD_ID, {
+        nextSession: timestamp,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        fiveMinuteWarningSent: false,
+      });
+
+      let settings = getSettings(TEST_GUILD_ID);
+      assert.isFalse(settings.fiveMinuteWarningSent);
+
+      // Update the flag
+      setSettings(TEST_GUILD_ID, {
+        nextSession: timestamp,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        fiveMinuteWarningSent: true,
+      });
+
+      settings = getSettings(TEST_GUILD_ID);
+      assert.isTrue(settings.fiveMinuteWarningSent);
+    });
+  });
+
+  describe("Scheduler Logic - Flag Reset", () => {
+    it("should reset both flags when a new session is set", () => {
+      const oldTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+
+      // Set initial session with flags
+      setSettings(TEST_GUILD_ID, {
+        nextSession: oldTimestamp,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        dayOfMessageSent: true,
+        fiveMinuteWarningSent: true,
+      });
+
+      let settings = getSettings(TEST_GUILD_ID);
+      assert.isTrue(settings.dayOfMessageSent);
+      assert.isTrue(settings.fiveMinuteWarningSent);
+
+      // Set new session (should reset flags)
+      const newTimestamp = Math.floor(Date.now() / 1000) + 86400; // Tomorrow
+      setSettings(TEST_GUILD_ID, {
+        nextSession: newTimestamp,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        dayOfMessageSent: false,
+        fiveMinuteWarningSent: false,
+      });
+
+      settings = getSettings(TEST_GUILD_ID);
+      assert.isFalse(settings.dayOfMessageSent);
+      assert.isFalse(settings.fiveMinuteWarningSent);
+      assert.equal(settings.nextSession, newTimestamp);
+    });
+  });
+
+  describe("Scheduler Logic - Missing Required Fields", () => {
+    it("should skip scheduling if nextSession is missing", () => {
+      setSettings(TEST_GUILD_ID, {
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      const shouldSkip = !settings.nextSession;
+
+      assert.isTrue(shouldSkip, "Should skip if nextSession is missing");
+    });
+
+    it("should skip scheduling if announcementChannel is missing", () => {
+      setSettings(TEST_GUILD_ID, {
+        nextSession: Math.floor(Date.now() / 1000) + 3600,
+        announcementRole: "role-456",
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      const shouldSkip = !settings.announcementChannel;
+
+      assert.isTrue(shouldSkip, "Should skip if announcementChannel is missing");
+    });
+
+    it("should skip scheduling if announcementRole is missing", () => {
+      setSettings(TEST_GUILD_ID, {
+        nextSession: Math.floor(Date.now() / 1000) + 3600,
+        announcementChannel: "channel-123",
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      const shouldSkip = !settings.announcementRole;
+
+      assert.isTrue(shouldSkip, "Should skip if announcementRole is missing");
+    });
+
+    it("should have all required fields if all are set", () => {
+      setSettings(TEST_GUILD_ID, {
+        nextSession: Math.floor(Date.now() / 1000) + 3600,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      const isComplete =
+        settings.nextSession && settings.announcementChannel && settings.announcementRole;
+
+      assert.isTrue(isComplete, "Should have all required fields");
+    });
+  });
+
+  describe("Scheduler Logic - Multi-Guild Iteration", () => {
+    it("should process settings for all configured guilds", () => {
+      const guild1 = "guild-1";
+      const guild2 = "guild-2";
+      const guild3 = "guild-3";
+
+      const settings = {
+        nextSession: Math.floor(Date.now() / 1000) + 3600,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+      };
+
+      setSettings(guild1, settings);
+      setSettings(guild2, settings);
+      setSettings(guild3, settings);
+
+      // Verify all are retrievable
+      assert.isNotNull(getSettings(guild1));
+      assert.isNotNull(getSettings(guild2));
+      assert.isNotNull(getSettings(guild3));
+
+      // Cleanup
+      deleteSettings(guild1);
+      deleteSettings(guild2);
+      deleteSettings(guild3);
+    });
+  });
+
+  describe("Scheduler Logic - Timestamp Handling", () => {
+    it("should correctly parse Unix timestamps (seconds)", () => {
+      const unixSeconds = Math.floor(Date.now() / 1000) + 3600;
+
+      setSettings(TEST_GUILD_ID, {
+        nextSession: unixSeconds,
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.equal(settings.nextSession, unixSeconds);
+
+      // Verify we can reconstruct the date correctly (within 1 second tolerance)
+      const reconstructed = new Date(settings.nextSession * 1000);
+      const expected = new Date(unixSeconds * 1000);
+      // Check they're equal within 1 second
+      assert.approximately(reconstructed.getTime(), expected.getTime(), 1000);
+    });
+
+    it("should handle past timestamps gracefully", () => {
+      const pastTime = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+
+      setSettings(TEST_GUILD_ID, {
+        nextSession: pastTime,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+        dayOfMessageSent: false,
+        fiveMinuteWarningSent: false,
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      const now = new Date();
+      const sessionTime = new Date(settings.nextSession * 1000);
+
+      // Verify session time is in the past
+      assert.isTrue(now.getTime() > sessionTime.getTime());
+    });
+  });
+
+  describe("Scheduler Logic - Flag Initialization", () => {
+    it("should initialize flags to false when not specified", () => {
+      setSettings(TEST_GUILD_ID, {
+        nextSession: Math.floor(Date.now() / 1000) + 3600,
+        announcementChannel: "channel-123",
+        announcementRole: "role-456",
+      });
+
+      const settings = getSettings(TEST_GUILD_ID);
+      assert.isFalse(settings.dayOfMessageSent);
+      assert.isFalse(settings.fiveMinuteWarningSent);
+    });
+  });
+});

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -5,32 +5,19 @@ const { setSettings, getSettings, deleteSettings, closeDatabase } = require("../
 
 const databasePath = path.resolve(__dirname, "..", "database.db");
 
-// Mock Discord Client and Channel
-const makeMockClient = () => ({
-  channels: {
-    fetch: async (channelId) => {
-      if (channelId === "valid-channel-id") {
-        return {
-          send: async (message) => ({
-            react: async (emoji) => {
-              // Mock reaction
-            },
-          }),
-        };
-      }
-      return null;
-    },
-  },
-});
-
 // We'll test the scheduler logic without actually scheduling
 describe("Scheduler Logic (Database Integration)", () => {
   const TEST_GUILD_ID = "test-guild-scheduler";
 
+  before(() => {
+    // Initialize database
+    require("../db/dal.js").getSettings("dummy");
+  });
+
   afterEach(() => {
     try {
       deleteSettings(TEST_GUILD_ID);
-    } catch (error) {
+    } catch (_error) { // eslint-disable-line no-unused-vars
       // Ignore
     }
   });
@@ -40,8 +27,8 @@ describe("Scheduler Logic (Database Integration)", () => {
     if (fs.existsSync(databasePath)) {
       try {
         fs.unlinkSync(databasePath);
-      } catch (error) {
-        console.warn("Could not delete test database:", error.message);
+      } catch (_error) {
+        console.warn("Could not delete test database:", _error.message);
       }
     }
   });
@@ -133,7 +120,6 @@ describe("Scheduler Logic (Database Integration)", () => {
         fiveMinuteWarningSent: false,
       });
 
-      const settings = getSettings(TEST_GUILD_ID);
       const now = new Date();
 
       // Verify the 5-minute window has not started yet (session is 10 min away)
@@ -245,10 +231,10 @@ describe("Scheduler Logic (Database Integration)", () => {
       });
 
       const settings = getSettings(TEST_GUILD_ID);
-      const isComplete =
-        settings.nextSession && settings.announcementChannel && settings.announcementRole;
-
-      assert.isTrue(isComplete, "Should have all required fields");
+      assert.isNotNull(settings, "Settings should exist");
+      assert.isNotNull(settings.nextSession, "nextSession should be set");
+      assert.equal(settings.announcementChannel, "channel-123", "announcementChannel should be set");
+      assert.equal(settings.announcementRole, "role-456", "announcementRole should be set");
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -4,14 +4,18 @@ const path = require("node:path");
 const setNextCommand = require("../src/commands/setnext.js");
 const nextCommand = require("../src/commands/next.js");
 const setOwnerCommand = require("../src/commands/setowner.js");
+const { getSettings, setSettings, setBotSetting, deleteSettings, getBotSetting } = require("../db/dal.js");
 
 const configPath = path.resolve(__dirname, "..", "config.json");
 
 // Mock message object
 let lastReply = "";
-const makeMockInteraction = ({ userId = "123456789", when = null } = {}) => ({
+const makeMockInteraction = ({ userId = "123456789", guildId = "test-guild", when } = {}) => ({
   user: { id: userId },
-  options: { getString: (k) => when },
+  guildId,
+  options: {
+    getString: (name) => name === "when" ? when : undefined,
+  },
   reply: (payload) => {
     if (typeof payload === "string") lastReply = payload;
     else if (payload?.content) lastReply = payload.content;
@@ -27,17 +31,38 @@ const makeMockInteraction = ({ userId = "123456789", when = null } = {}) => ({
 describe("Date Commands", () => {
   let originalConfig;
 
-  beforeEach(() => {
+  before(() => {
     // Save original config
     originalConfig = fs.readFileSync(configPath, "utf8");
     const config = JSON.parse(originalConfig);
     config.owner = "123456789";
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+
+    // Set owner in database
+    setBotSetting("owner", "123456789");
+  });
+
+  after(() => {
+    // Restore original config
+    fs.writeFileSync(configPath, originalConfig, "utf8");
+  });
+
+  beforeEach(() => {
+    // Clean up test data
+    try {
+      deleteSettings("test-guild");
+    } catch (error) {
+      console.error("Error cleaning up test data:", error.message);
+    }
   });
 
   afterEach(() => {
-    // Restore original config
-    fs.writeFileSync(configPath, originalConfig, "utf8");
+    // Clean up test data
+    try {
+      deleteSettings("test-guild");
+    } catch (error) {
+      console.error("Error cleaning up test data:", error.message);
+    }
   });
 
   it("!setnext should set the next session time", (done) => {
@@ -46,8 +71,8 @@ describe("Date Commands", () => {
     mockMessageWithDone.reply = (payload) => {
       const msg = typeof payload === "string" ? payload : payload.content;
       lastReply = msg;
-      const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-      assert.equal(config.nextSession, timestamp);
+      const settings = getSettings("test-guild");
+      assert.equal(settings.nextSession, timestamp);
       assert.include(lastReply, "Next session time has been set!");
       done();
     };
@@ -56,9 +81,7 @@ describe("Date Commands", () => {
 
   it("!next should display the next session time", () => {
     const timestamp = Math.floor(Date.now() / 1000);
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    config.nextSession = timestamp;
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+    setSettings("test-guild", { nextSession: timestamp });
 
     const mock = makeMockInteraction();
     nextCommand.execute(mock);
@@ -66,10 +89,6 @@ describe("Date Commands", () => {
   });
 
   it("!next should show a message if session is not set", () => {
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    config.nextSession = undefined;
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
-
     const mock = makeMockInteraction();
     nextCommand.execute(mock);
     assert.equal(
@@ -106,8 +125,8 @@ describe("Owner Commands", () => {
     mockMessageWithDone.reply = (payload) => {
       const msg = typeof payload === "string" ? payload : payload.content;
       lastReply = msg;
-      const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-      assert.equal(config.owner, "123456789");
+      const owner = getBotSetting("owner");
+      assert.equal(owner, "123456789");
       assert.equal(
         lastReply,
         "You have been set as the owner! You can now use the `/setnext` command.",
@@ -115,17 +134,13 @@ describe("Owner Commands", () => {
       done();
     };
     // Clear owner for the test
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    config.owner = undefined;
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+    setBotSetting("owner", null);
 
     setOwnerCommand.execute(mockMessageWithDone);
   });
 
   it("!setowner should not set the owner if one is already set", () => {
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    config.owner = "987654321";
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+    setBotSetting("owner", "987654321");
 
     const mock = makeMockInteraction();
     setOwnerCommand.execute(mock);


### PR DESCRIPTION
Refactor bot owner and role management commands to use database for settings

- Updated `setowner.js` to replace file-based config with database calls for owner management.
- Refactored `setrole.js` to utilize database for storing announcement role, ensuring only the owner can set it.
- Changed `index.js` to load the Discord token from environment variables instead of a config file.
- Added comprehensive tests for command functionalities and database interactions, ensuring robust error handling and multi-guild support.
- Introduced new tests for database operations, including settings retrieval, updates, and deletions.
- Implemented scheduler logic tests to validate session handling and flag management.